### PR TITLE
generates es2015 modules on npm run prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "1.0.0-alpha.3",
   "description": "Memoize decorator for Typescript",
   "main": "./dist/memoize-decorator.js",
+  "module": "./dist/es2015/memoize-decorator.js",
   "typings": "./dist/memoize-decorator.d.ts",
   "scripts": {
     "test": "karma start test/karma.config.js --single-run",
-    "prepublish": "npm run build",
+    "prepublish": "npm run build && npm run build:es2015",
     "clean": "rm -rf ./dist",
-    "build": "tsc"
+    "build": "tsc",
+    "build:es2015": "tsc --module es2015 --target es2015 --outDir dist/es2015"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Building the package should be now webpack/rollup compatible.

I have tested Issues #7 & #8 manually and they seem to work fine.




