### PR TITLE
remove core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,7 @@
     "url": "https://github.com/darrylhodgins/typescript-memoize/issues"
   },
   "homepage": "https://github.com/darrylhodgins/typescript-memoize#readme",
-  "dependencies": {
-    "core-js": "2.4.1"
-  },
   "devDependencies": {
-    "@types/core-js": "0.9.42",
     "@types/jasmine": "2.5.53",
     "@types/node": "8.0.17",
     "awesome-typescript-loader": "3.2.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,22 +18,10 @@
 		"importHelpers": true,
 		"noEmitHelpers": true,
 		"allowJs": false,
-		"types": [
-			"node",
-			"jasmine",
-			"core-js"
-		]
+		"types": ["node", "jasmine"]
 	},
-	"files": [
-		"src/memoize-decorator.ts"
-	],
-	"exclude": [
-		"coverage",
-		"dist",
-		"doc",
-		"node_modules",
-		"test"
-	],
+	"files": ["src/memoize-decorator.ts"],
+	"exclude": ["coverage", "dist", "doc", "node_modules", "test"],
 	"formatCodeOptions": {
 		"indentSize": 4,
 		"tabSize": 4,


### PR DESCRIPTION
I was getting a warning during installs because of the version of core-js that this package uses:

```sh
warning auto > @auto-it/core > typescript-memoize > core-js@2.4.1: core-js@<2.6.8 is no longer maintained. Please, upgrade to core-js@3 or at least to actual version of core-js@2.
```

I went to upgrade `core-js` but from what I could see it wasn't used directly anywhere or by any tool. Removing it didn't effect eh output of any of the scripts so it seems safe to remove.