### PR TITLE
Added a clear () function

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,15 +248,15 @@ clear(["foo"]);
 let greeterVal3 = clearableFoo.getClearableGreeting('Darryl', 'Mars');
 
 
-// The memoized value is not associated with 'foo' tag
+// The memoized value is not associated with 'foo' tag, returns memoized value
 // '3'
 let sum3 = clearableFoo.getClearableSum(2, 2);
 
 clear(["bar"]);
 
 // The memoized values are cleared, return a new value
-// 'Hello, Darryl! Welcome to Mars'
-let greeterVal4 = clearableFoo.getClearableGreeting('Darryl', 'Mars');
+// 'Hello, Darryl! Welcome to Earth'
+let greeterVal4 = clearableFoo.getClearableGreeting('Darryl', 'Earth');
 
 
 // The memoized values are cleared, return a new value

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ class MoreComplicatedFoo {
 		return greeting + '!!!!!';
 	}
 
+	// Memoize also accepts parameters via a single object argument
+	@Memoize({
+		expiring: 10000,
+		hashFunction: (name: string, planet: string) => {
+			return name + ';' + string;
+		}
+	})
+	public getSameBetterGreeting(name: string, planet: string) {
+		return 'Hello, ' + name + '! Welcome to ' + planet;
+	}
+
 }
 ```
 
@@ -175,9 +186,81 @@ let moreComplicatedFoo = new MoreComplicatedFoo();
 let greeterVal1 = moreComplicatedFoo.getBetterGreeting('Darryl', 'Earth');
 
 // 'Hello, Darryl! Welcome to Mars'
-let greeeterVal2 = moreComplicatedFoo.getBetterGreeting('Darryl', 'Mars');
+let greeterVal2 = moreComplicatedFoo.getBetterGreeting('Darryl', 'Mars');
 
 // Fill up the computer with useless greetings:
 let greeting = moreComplicatedFoo.memoryLeak('Hello');
+
+```
+
+## Memoize accepts one or more "tag" strings that allow the cache to be invalidated on command
+
+Passing an array with one or more "tag" strings these will allow you to later clear the cache of results associated with methods or the `get`accessors using the `clear()` function.
+
+The `clear()` function also requires an array of "tag" strings.
+
+```typescript
+import {Memoize} from 'typescript-memoize';
+
+class ClearableFoo {
+
+	// Memoize accepts tags
+	@Memoize({ tags: ["foo", "bar"] })
+	public getClearableGreeting(name: string, planet: string) {
+		return 'Hello, ' + name + '! Welcome to ' + planet;
+	}
+
+
+	// Memoize accepts tags
+	@Memoize({ tags: ["bar"] })
+	public getClearableSum(a: number, b: number) {
+		return a + b;
+	}
+
+}
+```
+
+We call these methods from somewhere else in our code.
+
+```typescript
+import {clear} from 'typescript-memoize';
+
+let clearableFoo = new ClearableFoo();
+
+// 'Hello, Darryl! Welcome to Earth'
+let greeterVal1 = clearableFoo.getClearableGreeting('Darryl', 'Earth');
+
+// Ignores the second parameter, and returns memoized value
+// 'Hello, Darryl! Welcome to Earth'
+let greeterVal2 = clearableFoo.getClearableGreeting('Darryl', 'Mars');
+
+// '3'
+let sum1 = clearableFoo.getClearableSum(2, 1);
+
+// Ignores the second parameter, and returns memoized value
+// '3'
+let sum2 = clearableFoo.getClearableSum(2, 2);
+
+clear(["foo"]);
+
+// The memoized values are cleared, return a new value
+// 'Hello, Darryl! Welcome to Mars'
+let greeterVal3 = clearableFoo.getClearableGreeting('Darryl', 'Mars');
+
+
+// The memoized value is not associated with 'foo' tag
+// '3'
+let sum3 = clearableFoo.getClearableSum(2, 2);
+
+clear(["bar"]);
+
+// The memoized values are cleared, return a new value
+// 'Hello, Darryl! Welcome to Mars'
+let greeterVal4 = clearableFoo.getClearableGreeting('Darryl', 'Mars');
+
+
+// The memoized values are cleared, return a new value
+// '4'
+let sum4 = clearableFoo.getClearableSum(2, 2);
 
 ```

--- a/src/memoize-decorator.ts
+++ b/src/memoize-decorator.ts
@@ -4,12 +4,12 @@ interface MemoizeArgs {
 	tags?: string[];
 }
 
-export function Memoize(args?: MemoizeArgs | MemoizeArgs["hashFunction"]) {
-	let hashFunction: MemoizeArgs["hashFunction"];
-	let duration: MemoizeArgs["expiring"];
-	let tags: MemoizeArgs["tags"];
+export function Memoize(args?: MemoizeArgs | MemoizeArgs['hashFunction']) {
+	let hashFunction: MemoizeArgs['hashFunction'];
+	let duration: MemoizeArgs['expiring'];
+	let tags: MemoizeArgs['tags'];
 
-	if(typeof args === "object") {
+	if (typeof args === 'object') {
 		hashFunction = args.hashFunction;
 		duration = args.expiring;
 		tags = args.tags;
@@ -28,7 +28,7 @@ export function Memoize(args?: MemoizeArgs | MemoizeArgs["hashFunction"]) {
 	};
 }
 
-export function MemoizeExpiring(expiring: number, hashFunction?: MemoizeArgs["hashFunction"]) {
+export function MemoizeExpiring(expiring: number, hashFunction?: MemoizeArgs['hashFunction']) {
 	return Memoize({
 		expiring,
 		hashFunction
@@ -39,10 +39,10 @@ const clearCacheTagsMap: Map<string, Map<any, any>[]> = new Map();
 
 export function clear (tags: string[]): number {
 	const cleared: Set<Map<any, any>> = new Set();
-	for(const tag of tags) {
+	for (const tag of tags) {
 		const maps = clearCacheTagsMap.get(tag);
-		for(const mp of maps) {
-			if(!cleared.has(mp)) {
+		for (const mp of maps) {
+			if (!cleared.has(mp)) {
 				mp.clear();
 				cleared.add(mp);
 			}
@@ -51,7 +51,7 @@ export function clear (tags: string[]): number {
 	return cleared.size;
 }
 
-function getNewFunction(originalMethod: () => void, hashFunction?: MemoizeArgs["hashFunction"], duration: number = 0, tags?: MemoizeArgs["tags"]) {
+function getNewFunction(originalMethod: () => void, hashFunction?: MemoizeArgs['hashFunction'], duration: number = 0, tags?: MemoizeArgs['tags']) {
 	const propMapName = Symbol(`__memoized_map__`);
 
 	// The function returned here gets called instead of originalMethod.
@@ -69,9 +69,9 @@ function getNewFunction(originalMethod: () => void, hashFunction?: MemoizeArgs["
 		}
 		let myMap: Map<any, any> = this[propMapName];
 
-		if(Array.isArray(tags)) {
-			for(const tag of tags) {
-				if(clearCacheTagsMap.has(tag)) {
+		if (Array.isArray(tags)) {
+			for (const tag of tags) {
+				if (clearCacheTagsMap.has(tag)) {
 					clearCacheTagsMap.get(tag).push(myMap);
 				} else {
 					clearCacheTagsMap.set(tag, [myMap]);

--- a/src/memoize-decorator.ts
+++ b/src/memoize-decorator.ts
@@ -41,10 +41,12 @@ export function clear (tags: string[]): number {
 	const cleared: Set<Map<any, any>> = new Set();
 	for (const tag of tags) {
 		const maps = clearCacheTagsMap.get(tag);
-		for (const mp of maps) {
-			if (!cleared.has(mp)) {
-				mp.clear();
-				cleared.add(mp);
+		if (maps) {
+			for (const mp of maps) {
+				if (!cleared.has(mp)) {
+					mp.clear();
+					cleared.add(mp);
+				}
 			}
 		}
 	}

--- a/test/specs/memoize-decorator.spec.ts
+++ b/test/specs/memoize-decorator.spec.ts
@@ -1,4 +1,4 @@
-import { Memoize, MemoizeExpiring } from '../../src/memoize-decorator';
+import { clear, Memoize, MemoizeExpiring } from '../../src/memoize-decorator';
 import exp = require('constants');
 
 describe('Memoize()', () => {
@@ -22,7 +22,6 @@ describe('Memoize()', () => {
 		getGreetingSpy.calls.reset();
 		multiplySpy.calls.reset();
 	});
-
 	class MyClass {
 		@Memoize()
 		public getNumber(): number {
@@ -61,8 +60,47 @@ describe('Memoize()', () => {
 			getGreetingSpy.apply(this, arguments);
 			return greeting + ', ' + planet;
 		}
+
+		@Memoize({
+			hashFunction: (a: number, b: number) => {
+				return a + ';' + b;
+			}
+		})
+		public multiply3(a: number, b: number) {
+			multiplySpy.apply(this, arguments);
+			return a * b;
+		}
+
+		@Memoize({
+			hashFunction: true
+		})
+		public getGreeting3(greeting: string, planet: string): string {
+			getGreetingSpy.apply(this, arguments);
+			return greeting + ', ' + planet;
+		}
+
+		@Memoize({
+			hashFunction: true,
+			tags: ["foo", "bar"]
+		})
+		public getGreeting4(greeting: string, planet: string): string {
+			getGreetingSpy.apply(this, arguments);
+			return greeting + ', ' + planet;
+		}
 	}
 
+	describe('when it is used in a bad way', () => {
+		it("method throw an exception", () => {
+			let err: Error;
+			try {
+				const fn = Memoize(true) as any;
+				fn();
+			} catch(e) {
+				err = e;
+			}
+			expect(err).toBeInstanceOf(Error);
+	    });
+	});
 
 	describe('when decorating a method', () => {
 		it("method should be memoized", () => {
@@ -157,7 +195,7 @@ describe('Memoize()', () => {
 		});
 	});
 
-	describe('when passgin true to memoize as a hashFunction', () => {
+	describe('when passing true to memoize as a hashFunction', () => {
 		it('should call the original method with the original arguments', () => {
 			let val1 = a.multiply2(5, 7);
 			expect(multiplySpy).toHaveBeenCalledWith(5, 7);
@@ -182,6 +220,51 @@ describe('Memoize()', () => {
 			expect(getGreetingSpy).toHaveBeenCalledTimes(2);
 		});
 
+	});
+
+	describe('when passing arguments as arguments object', () => {
+		it('should call the original method with the original arguments', () => {
+			let val1 = a.multiply3(5, 7);
+			expect(multiplySpy).toHaveBeenCalledWith(5, 7);
+		});
+
+		it('should only call the original method once', () => {
+			let val1 = a.multiply3(4, 6);
+			let val2 = a.multiply3(4, 6);
+			expect(val1).toEqual(24);
+			expect(val2).toEqual(24);
+			expect(multiplySpy.calls.count()).toEqual(1);
+		});
+
+		it('should take into consideration every parameter', () => {
+			let val1 = a.getGreeting3('Hello', 'World');
+			let val2 = a.getGreeting3('Hello', 'Moon');
+
+			expect(val1).toEqual('Hello, World');
+			expect(val2).toEqual('Hello, Moon');
+
+			expect(getGreetingSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it('should be cleared ', () => {
+			let val1 = a.getGreeting4('Hello', 'World');
+			let val2 = a.getGreeting4('Hello', 'Moon');
+			let val3 = a.getGreeting4('Hello', 'World');
+			clear(["foo"]);
+			let val4 = a.getGreeting4('Hello', 'Moon');
+			let val5 = a.getGreeting4('Hello', 'World');
+			clear(["bar"]);
+			let val6 = a.getGreeting4('Hello', 'World');
+
+			expect(val1).toEqual('Hello, World');
+			expect(val2).toEqual('Hello, Moon');
+			expect(val3).toEqual('Hello, World');
+			expect(val4).toEqual('Hello, Moon');
+			expect(val5).toEqual('Hello, World');
+			expect(val6).toEqual('Hello, World');
+
+			expect(getGreetingSpy).toHaveBeenCalledTimes(5);
+		});
 
 	});
 

--- a/test/specs/memoize-decorator.spec.ts
+++ b/test/specs/memoize-decorator.spec.ts
@@ -256,6 +256,8 @@ describe('Memoize()', () => {
 			clear(["bar"]);
 			let val6 = a.getGreeting4('Hello', 'World');
 
+			clear(["unknown"]);
+
 			expect(val1).toEqual('Hello, World');
 			expect(val2).toEqual('Hello, Moon');
 			expect(val3).toEqual('Hello, World');
@@ -267,7 +269,6 @@ describe('Memoize()', () => {
 		});
 
 	});
-
 
 });
 


### PR DESCRIPTION
As proposed in issue #13, and as it turned out to be necessary for me to have in a project I am working on, I have implemented a function to invalidate the cache of stored values.

The implementation takes place through the association of "tag" strings that allow you to have a reference with the saved results.

The use case is when in a webapp it is necessary to guarantee access to the updated result of a function that is usually memorized permanently or for a long time (with expiring).