### PR TITLE
Use the property key in the name of the cache

### DIFF
--- a/src/memoize-decorator.ts
+++ b/src/memoize-decorator.ts
@@ -2,9 +2,9 @@ export function Memoize(autoHashOrHashFn?: boolean | ((...args: any[]) => any)) 
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) => {
 
 		if (descriptor.value != null) {
-			descriptor.value = getNewFunction(descriptor.value, autoHashOrHashFn);
+			descriptor.value = getNewFunction(propertyKey, descriptor.value, autoHashOrHashFn);
 		} else if (descriptor.get != null) {
-			descriptor.get = getNewFunction(descriptor.get, autoHashOrHashFn);
+			descriptor.get = getNewFunction(propertyKey, descriptor.get, autoHashOrHashFn);
 		} else {
 			throw 'Only put a Memoize() decorator on a method or get accessor.';
 		}
@@ -16,9 +16,9 @@ export function MemoizeExpiring(duration: number, autoHashOrHashFn?: boolean | (
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) => {
 
 		if (descriptor.value != null) {
-			descriptor.value = getNewFunction(descriptor.value, autoHashOrHashFn, duration);
+			descriptor.value = getNewFunction(propertyKey, descriptor.value, autoHashOrHashFn, duration);
 		} else if (descriptor.get != null) {
-			descriptor.get = getNewFunction(descriptor.get, autoHashOrHashFn, duration);
+			descriptor.get = getNewFunction(propertyKey, descriptor.get, autoHashOrHashFn, duration);
 		} else {
 			throw 'Only put a Memoize() decorator on a method or get accessor.';
 		}
@@ -26,14 +26,11 @@ export function MemoizeExpiring(duration: number, autoHashOrHashFn?: boolean | (
 	};
 }
 
-let counter = 0;
-function getNewFunction(originalMethod: () => void, autoHashOrHashFn?: boolean | ((...args: any[]) => any), duration: number = 0) {
-	const identifier = ++counter;
-
+function getNewFunction(propertyKey: string, originalMethod: () => void, autoHashOrHashFn?: boolean | ((...args: any[]) => any), duration: number = 0) {
 	// The function returned here gets called instead of originalMethod.
 	return function (...args: any[]) {
-		const propValName = `__memoized_value_${identifier}`;
-		const propMapName = `__memoized_map_${identifier}`;
+		const propValName = `__memoized_value_${propertyKey}`;
+		const propMapName = `__memoized_map_${propertyKey}`;
 
 		let returnedValue: any;
 


### PR DESCRIPTION
I’m proposing a change to how the cache keys are generated: instead of using a counter, let’s use the name of the property itself.

### Example

```js
@Memoize()
get expensiveComputation() {
  // ...
}
```

Instead of caching this as:
`__memoized_value_1`

We use:
`__memoized_value_expensiveComputation`

### Why

The main reason to do this is to avoid a — arguably rare — situation where this dependency is included more than once in a project.

Here’s a hypothetical situation: you have a repository with multiple packages. You decide to extract a common, shared `Base` class into a separate package called `common`. You then extend from this class in your main `app` package.

```js
// packages/common/src/base.js
import { Memoize } from 'typescript-memoize';

export default class Base {
  @Memoize()
  get first() {
	// ...
  }
}
```

```js
// packages/app/src/component.js
import { Memoize } from 'typescript-memoize';
import Base from 'common/base';

class Component extends Base {
  @Memoize()
  get overwriteFirst() {
  // ...
  }
}
```

For each package, you specify `typescript-memoize` as a dependency in its respective `package.json`. Unfortunately, depending on the way packages and modules are resolved, these two classes could end up using two separate instances of this module. And since the current cache keys are based on counters that are scoped to the module, this can lead to two different properties writing to the same cache key.

```js
let component = new Component();
component.first;          // set __memoize_value_1
component.overwriteFirst; // set __memoize_value_1 again!
component.first           // get __memoize_value_1. Oh no!
```

One real world example where this has been a problem is the multi-package repo [`embroider-build/embroider`](https://github.com/embroider-build/embroider/issues/769) — a compiler for Ember apps. When installed with yarn, specifically, each internal package gets its own version of `typescript-memoize`, leading to all sorts of build errors.