### PR TITLE
Fix memory leak

### DIFF
--- a/test/specs/memoize-decorator.spec.ts
+++ b/test/specs/memoize-decorator.spec.ts
@@ -252,9 +252,10 @@ describe('Memoize()', () => {
 			let val3 = a.getGreeting4('Hello', 'World');
 			clear(["foo"]);
 			let val4 = a.getGreeting4('Hello', 'Moon');
-			let val5 = a.getGreeting4('Hello', 'World');
-			clear(["bar"]);
+			let val5 = a.getGreeting4('Hello', 'Moon');
 			let val6 = a.getGreeting4('Hello', 'World');
+			clear(["bar"]);
+			let val7 = a.getGreeting4('Hello', 'World');
 
 			clear(["unknown"]);
 
@@ -262,8 +263,9 @@ describe('Memoize()', () => {
 			expect(val2).toEqual('Hello, Moon');
 			expect(val3).toEqual('Hello, World');
 			expect(val4).toEqual('Hello, Moon');
-			expect(val5).toEqual('Hello, World');
+			expect(val5).toEqual('Hello, Moon');
 			expect(val6).toEqual('Hello, World');
+			expect(val7).toEqual('Hello, World');
 
 			expect(getGreetingSpy).toHaveBeenCalledTimes(5);
 		});


### PR DESCRIPTION
I turns out there is a memory leak when we use `Memoize` in combination with `tags`.
For every new instance we push it's cache map to this array [here](https://github.com/darrylhodgins/typescript-memoize/blob/master/src/memoize-decorator.ts#L77), this means this array just keeps growing, event if the instance that uses that map may not be used any more (already got garbage collected)

To resolve the issue, instead of saving all these maps in an array under the tag as a key, what we do is we assign each tag a version (a unique symbol), after `clear` is called for a tag, we update the version of the tag.

Every time a method is called we compare it's tag version (which we save on a per instance basis), with the latest global tag version, if there is a missmatch it means we need to clear the cache for the instance, and update it's tag version with the latest.

Unfortunately this is a breaking change, as with this implementation there is no way for the `clear` function to return a number any more